### PR TITLE
fix: avoid tool_choice for Google models

### DIFF
--- a/infinigpt/app.py
+++ b/infinigpt/app.py
@@ -154,8 +154,9 @@ class AppContext:
             "model": use_model,
             "messages": messages,
             "tools": self.tools_schema,
-            "tool_choice": tool_choice,
         }
+        if use_model not in self.cfg.llm.models.get("google", []) and tool_choice != "auto":
+            data["tool_choice"] = tool_choice
         if (
                     use_model not in self.cfg.llm.models.get("google", [])
                     and use_model != "grok-4"
@@ -208,7 +209,9 @@ class AppContext:
                     tool_msg["tool_call_id"] = call["id"]
                 messages.append(tool_msg)
             try:
-                data = {"model": use_model, "messages": messages, "tools": self.tools_schema, "tool_choice": tool_choice}
+                data = {"model": use_model, "messages": messages, "tools": self.tools_schema}
+                if use_model not in self.cfg.llm.models.get("google", []) and tool_choice != "auto":
+                    data["tool_choice"] = tool_choice
                 if (
                     use_model not in self.cfg.llm.models.get("google", [])
                     and use_model != "grok-4"


### PR DESCRIPTION
## Summary
- Avoid sending `tool_choice` when using Google Gemini OpenAI-compatible models
- Prevents 400 errors from unsupported parameter during tool calls

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb4eb763788327924287b49155d80a