### PR TITLE
Use host network mode for Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     container_name: infinigpt-matrix
     image: infinigpt-matrix:latest
     user: "YOUR UID:YOUR GID"
+    network_mode: host
     environment:
       - OPENAI_API_KEY
       - XAI_API_KEY

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -30,11 +30,12 @@ mkdir -p store
 cp config.json ./config.json  # ensure it contains Matrix creds, rooms, models
 ```
 
-2) Run the container:
+2) Run the container with `--network host` so it can reach any local MCP servers on the host:
 
 ```bash
 docker run --rm -it \
   --name infinigpt \
+  --network host \
   -v "$(pwd)/config.json":/data/config.json:ro \
   -v "$(pwd)/store":/data/store \
   -v "$(pwd)/images":/data/images \
@@ -50,6 +51,7 @@ docker run --rm -it \
 
 Notes:
 
+- `--network host` shares the host's network stack with the container, so `localhost` URLs in your config (MCP servers, etc.) work directly.
 - The bot does not expose ports; it connects out to Matrix and any providers you configure.
 - Persist `/data/store` to retain device keys for E2E rooms.
 
@@ -63,6 +65,7 @@ services:
     image: infinigpt-matrix:latest
     user: "YOUR UID:YOUR GID"
     container_name: infinigpt-matrix
+    network_mode: host
     environment:
       - OPENAI_API_KEY
       - XAI_API_KEY

--- a/docs/tools-and-mcp.md
+++ b/docs/tools-and-mcp.md
@@ -72,9 +72,14 @@ Behavior notes:
 - If a server is defined with `command`/`args`, stderr is silenced; stdout is preserved for MCP stdio.
 - Duplicate names: MCP tools override built‑in tools with the same name.
 
+### Docker
+
+When running in Docker, use `--network host` so the container can reach MCP servers on localhost. See [Docker](docker.md) for details. Stdio/command‑based MCP servers require the binary to be installed in the container image; prefer URL‑based servers when running in Docker.
+
 ## Troubleshooting
 
 - Model never calls tools: ensure your model supports tool/function calling and that tools appear in logs at startup (use `-L DEBUG`).
 - HTTP/network errors from tools: check your environment’s network and any proxies/firewalls. MCP servers must be reachable.
+- MCP tools not loading in Docker: make sure you’re using `--network host`. See [Docker](docker.md).
 - Built‑in tool not found: confirm the function name in `schema.json` matches the Python function name and module is importable.
 


### PR DESCRIPTION
## Summary
- Add `--network host` / `network_mode: host` to Docker run examples and docker-compose.yml
- Update Docker and MCP docs to document host networking
- Ensures local MCP servers on localhost are reachable from the container

See h1ddenpr0cess20/ollamarama-matrix#56 for the original issue and fix.

## Test plan
- [x] Run bot in Docker with `--network host` and verify local MCP servers load

🤖 Generated with [Claude Code](https://claude.com/claude-code)